### PR TITLE
Simplify configuration for Capella

### DIFF
--- a/src/main/java/org/couchbase/quickstart/configs/CouchbaseConfig.java
+++ b/src/main/java/org/couchbase/quickstart/configs/CouchbaseConfig.java
@@ -1,19 +1,16 @@
 package org.couchbase.quickstart.configs;
 
-import com.couchbase.client.core.deps.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import com.couchbase.client.core.env.IoConfig;
-import com.couchbase.client.core.env.SecurityConfig;
-import com.couchbase.client.core.error.BucketExistsException;
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.ClusterOptions;
-import com.couchbase.client.java.env.ClusterEnvironment;
 import com.couchbase.client.java.manager.bucket.BucketSettings;
 import com.couchbase.client.java.manager.bucket.BucketType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.nio.file.Paths;
 
 @Configuration
 public class CouchbaseConfig {
@@ -22,30 +19,40 @@ public class CouchbaseConfig {
     private DBProperties dbProp;
 
     /**
-     * NOTE: To connect with Couchbase CAPELLA please use the commented method bellow as it requires TLS
+     * NOTE: If connecting to Couchbase Capella, you must enable TLS.
+     * <p>
+     * The simplest way to enable TLS is to edit {@code application.properties}
+     * and make sure the {@code spring.couchbase.bootstrap-hosts} config property
+     * starts with "couchbases://" (note the final 's'), like this:
+     * <pre>
+     * spring.couchbase.bootstrap-hosts=couchbases://my-cluster.cloud.couchbase.com
+     * </pre>
+     * Alternatively, you can enable TLS by writing code to configure the cluster environment;
+     * see the commented-out code in this method for an example.
      */
-/*  @Bean
-    public Cluster getCouchbaseCluster(){
-        ClusterEnvironment env = ClusterEnvironment.builder()
-                .securityConfig(SecurityConfig.enableTls(true)
-                        .trustManagerFactory(InsecureTrustManagerFactory.INSTANCE))
-                .ioConfig(IoConfig.enableDnsSrv(true))
-                .build();
-        return Cluster.connect(dbProp.getHostName(),
-                ClusterOptions.clusterOptions(dbProp.getUsername(), dbProp.getPassword()).environment(env));
-    }
-*/
-
-    /**
-     * NOTE: To connect with Couchbase locally use the methode bellow
-     */
-    @Bean
-    public Cluster getCouchbaseCluster(){
+    @Bean(destroyMethod = "disconnect")
+    public Cluster getCouchbaseCluster() {
         return Cluster.connect(dbProp.getHostName(), dbProp.getUsername(), dbProp.getPassword());
+
+        // Here is an alternative version that enables TLS by configuring the cluster environment.
+/*      return Cluster.connect(
+            dbProp.getHostName(),
+            ClusterOptions.clusterOptions(dbProp.getUsername(), dbProp.getPassword())
+                .environment(env -> { // Configure cluster environment properties here
+                    env.securityConfig().enableTls(true);
+
+                    // If you're connecting to Capella, the SDK already knows which certificates to trust.
+                    // When using TLS with non-Capella clusters, you must tell the SDK which certificates to trust.
+                    env.securityConfig().trustCertificate(
+                        Paths.get("/path/to/trusted-root-certificate.pem")
+                    );
+                })
+        );
+ */
     }
 
     @Bean
-    public Bucket getCouchbaseBucket(Cluster cluster){
+    public Bucket getCouchbaseBucket(Cluster cluster) {
 
         // Creates the cluster if it does not exist yet
         if (!cluster.buckets().getAllBuckets().containsKey(dbProp.getBucketName())) {


### PR DESCRIPTION
Take advantage of the Capella CA certificate bundled with Java SDK 3.3.0.

Add a note that the simplest way to enable TLS is to treat the
`spring.couchbase.bootstrap-hosts` application property as a
connection string, and prefix it with "couchbases://".

In the commented-out example code, configure the ClusterEnvironment
using a lambda. This way, the user is not responsible for shutting down
the environment.

Disconnect the cluster when the bean is destroyed. It doesn't matter
for this example project, but it's a good practice that prevents
resource leakage when the Spring webapp is undeployed from a
non-embedded app server.